### PR TITLE
feat: add Naver refresh token grant support

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -152,7 +152,31 @@ try {
 }
 ```
 
-**2. 사용자 정보 가져오기**
+**2. 리프레시 토큰으로 액세스 토큰 갱신**
+```java
+NaverClient naverClient = NaverClient.create();
+
+try {
+     NaverRefreshTokenResponse response = naverClient.refreshToken()
+             .clientId("YOUR_CLIENT_ID")
+             .clientSecret("YOUR_CLIENT_SECRET")
+             .refreshToken("USER_REFRESH_TOKEN")
+             .build()
+             .execute();
+
+    System.out.println("갱신된 액세스 토큰: " + response.accessToken());
+} catch (OAuthException e) {
+    e.printStackTrace();
+}
+```
+
+네이버 토큰 갱신 주의사항:
+- 네이버는 토큰 발급과 토큰 갱신에 같은 엔드포인트를 사용하지만 `grant_type`에 따라 필수 파라미터가 달라집니다.
+- 토큰 갱신 응답은 공식 문서의 출력 결과 형식을 따르며 `refresh_token`은 포함하지 않습니다.
+- 네이버는 HTTP `200 OK`를 반환하더라도 응답 본문에 `error`, `error_description`를 담아 실패를 표현할 수 있습니다.
+- 라이브러리는 이러한 응답을 `OAuthResponseException`으로 변환합니다.
+
+**3. 사용자 정보 가져오기**
 ```java
 NaverClient naverClient = NaverClient.create();
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,31 @@ try {
 }
 ```
 
-**2. Get User Profile**
+**2. Refresh Access Token with a Refresh Token**
+```java
+NaverClient naverClient = NaverClient.create();
+
+try {
+    NaverRefreshTokenResponse response = naverClient.refreshToken()
+            .clientId("YOUR_CLIENT_ID")
+            .clientSecret("YOUR_CLIENT_SECRET")
+            .refreshToken("USER_REFRESH_TOKEN")
+            .build()
+            .execute();
+
+    System.out.println("Refreshed Access Token: " + response.accessToken());
+} catch (OAuthException e) {
+    e.printStackTrace();
+}
+```
+
+Naver refresh token notes:
+- Naver uses the same token endpoint for token issuance and token refresh, but the required parameters differ by `grant_type`.
+- The refresh token response follows the official refresh output fields and does not include `refresh_token`.
+- Naver may return HTTP `200 OK` with `error` and `error_description` in the response body.
+- The library converts those responses into `OAuthResponseException`.
+
+**3. Get User Profile**
 ```java
 NaverClient naverClient = NaverClient.create();
 

--- a/src/main/java/kr/higu/client/NaverClient.java
+++ b/src/main/java/kr/higu/client/NaverClient.java
@@ -2,6 +2,7 @@ package kr.higu.client;
 
 import kr.higu.IHttpManager;
 import kr.higu.OAuthHttpManager;
+import kr.higu.request.naver.NaverRefreshTokenRequest;
 import kr.higu.request.naver.NaverTokenRequest;
 import kr.higu.request.naver.NaverUserRequest;
 
@@ -9,8 +10,8 @@ import kr.higu.request.naver.NaverUserRequest;
  * The main entry point for interacting with Naver OAuth services.
  * <p>
  * This client provides access to Naver-specific request builders,
- * allowing developers to easily exchange authorization codes for tokens
- * and retrieve user profile information.
+ * allowing developers to easily exchange authorization codes for tokens,
+ * refresh tokens, and retrieve user profile information.
  * </p>
  *
  * <pre>{@code
@@ -20,6 +21,13 @@ import kr.higu.request.naver.NaverUserRequest;
  * .clientSecret("YOUR_CLIENT_SECRET")
  * .code("AUTHORIZATION_CODE")
  * .state("YOUR_STATE")
+ * .build()
+ * .execute();
+ *
+ * NaverRefreshTokenResponse refreshed = client.refreshToken()
+ * .clientId("YOUR_CLIENT_ID")
+ * .clientSecret("YOUR_CLIENT_SECRET")
+ * .refreshToken("USER_REFRESH_TOKEN")
  * .build()
  * .execute();
  * }</pre>
@@ -67,6 +75,16 @@ public class NaverClient {
      */
     public NaverTokenRequest.Builder getToken() {
         return new NaverTokenRequest.Builder(httpManager);
+    }
+
+    /**
+     * Provides a builder for creating a {@link NaverRefreshTokenRequest}.
+     * Use this to refresh an access token with Naver's auth server.
+     *
+     * @return A builder for NaverRefreshTokenRequest.
+     */
+    public NaverRefreshTokenRequest.Builder refreshToken() {
+        return new NaverRefreshTokenRequest.Builder(httpManager);
     }
 
     /**

--- a/src/main/java/kr/higu/dto/naver/NaverRefreshTokenResponse.java
+++ b/src/main/java/kr/higu/dto/naver/NaverRefreshTokenResponse.java
@@ -1,0 +1,22 @@
+package kr.higu.dto.naver;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response DTO for the "Access token refresh request" output fields in the Naver Login API.
+ *
+ * @see <a href="https://developers.naver.com/docs/login/api/api.md">Naver Refresh Token Documentation</a>
+ * @author higukang
+ */
+public record NaverRefreshTokenResponse(
+        /** The refreshed token used to access protected resources. */
+        @SerializedName("access_token") String accessToken,
+        /** Type of the token (e.g., "bearer"). */
+        @SerializedName("token_type") String tokenType,
+        /** Lifetime of the access token in seconds. */
+        @SerializedName("expires_in") String expiresIn,
+        /** Error code returned by Naver. */
+        @SerializedName("error") String error,
+        /** Error description returned by Naver. */
+        @SerializedName("error_description") String errorDescription
+) {}

--- a/src/main/java/kr/higu/request/naver/NaverRefreshTokenRequest.java
+++ b/src/main/java/kr/higu/request/naver/NaverRefreshTokenRequest.java
@@ -1,0 +1,144 @@
+package kr.higu.request.naver;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import kr.higu.IHttpManager;
+import kr.higu.dto.naver.NaverRefreshTokenResponse;
+import kr.higu.exceptions.OAuthException;
+import kr.higu.exceptions.detailed.OAuthParsingException;
+import kr.higu.exceptions.detailed.OAuthResponseException;
+import kr.higu.request.AbstractRequest;
+import kr.higu.request.ErrorDetail;
+
+import java.net.URI;
+
+/**
+ * Request class for refreshing a Naver access token with a refresh token.
+ * This class follows the refresh token flow in the Naver Login API.
+ *
+ * @see <a href="https://developers.naver.com/docs/login/api/api.md">Naver Token API Documentation</a>
+ * @author higukang
+ */
+public class NaverRefreshTokenRequest extends AbstractRequest<NaverRefreshTokenResponse> {
+
+    private NaverRefreshTokenRequest(Builder builder) {
+        super(builder);
+    }
+
+    /**
+     * Builder for creating {@link NaverRefreshTokenRequest} instances.
+     * Requires clientId, clientSecret, and refreshToken to be set.
+     */
+    public static class Builder extends AbstractRequest.Builder<NaverRefreshTokenResponse, Builder> {
+
+        /**
+         * Initializes the builder with Naver-specific default headers and refresh grant type.
+         *
+         * @param httpManager The HTTP manager to use for the request.
+         */
+        public Builder(IHttpManager httpManager) {
+            super(httpManager, NaverRefreshTokenResponse.class);
+            this.setHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+            this.addParam("grant_type", "refresh_token");
+        }
+
+        /**
+         * Sets the Client ID issued when registering the application on Naver Developers.
+         *
+         * @param clientId The Naver Client ID.
+         * @return This builder instance.
+         */
+        public Builder clientId(String clientId) {
+            return addParam("client_id", clientId);
+        }
+
+        /**
+         * Sets the Client Secret issued when registering the application on Naver Developers.
+         *
+         * @param clientSecret The Naver Client Secret.
+         * @return This builder instance.
+         */
+        public Builder clientSecret(String clientSecret) {
+            return addParam("client_secret", clientSecret);
+        }
+
+        /**
+         * Sets the refresh token previously issued by Naver.
+         *
+         * @param refreshToken The refresh token.
+         * @return This builder instance.
+         */
+        public Builder refreshToken(String refreshToken) {
+            return addParam("refresh_token", refreshToken);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        /**
+         * Validates mandatory parameters and builds the {@link NaverRefreshTokenRequest}.
+         *
+         * @return A new request instance.
+         * @throws kr.higu.exceptions.OAuthValidationException If any required parameter is missing.
+         */
+        @Override
+        public NaverRefreshTokenRequest build() {
+            validate("grant_type", "client_id", "client_secret", "refresh_token");
+            return new NaverRefreshTokenRequest(this);
+        }
+    }
+
+    @Override
+    protected String getMethod() { return "POST"; }
+
+    @Override
+    protected URI getUri() {
+        return URI.create("https://nid.naver.com/oauth2.0/token");
+    }
+
+    /**
+     * Parses error responses from the Naver Auth Server.
+     * Naver uses 'error' and 'error_description' fields in its JSON error body.
+     *
+     * @param errorBody The raw JSON error response.
+     * @return A parsed {@link ErrorDetail}.
+     */
+    @Override
+    protected ErrorDetail parseError(String errorBody) {
+        try {
+            JsonObject json = JsonParser.parseString(errorBody).getAsJsonObject();
+            String errorCode = json.has("error") ? json.get("error").getAsString() : "NAVER_AUTH_ERROR";
+            String message = json.has("error_description") ? json.get("error_description").getAsString() : "No description provided";
+            return new ErrorDetail(errorCode, message);
+        } catch (Exception e) {
+            return new ErrorDetail("PARSING_ERROR", "Failed to parse Naver auth error: " + errorBody);
+        }
+    }
+
+    /**
+     * Handles the Naver case where the server returns a 200 OK status
+     * but the response body contains an 'error' field.
+     *
+     * @param responseBody The raw response body from Naver.
+     * @throws OAuthException If the body contains an 'error' field or the response cannot be parsed.
+     */
+    @Override
+    protected void validateSuccessResponse(String responseBody) throws OAuthException {
+        final JsonObject json;
+        try {
+            json = JsonParser.parseString(responseBody).getAsJsonObject();
+        } catch (Exception e) {
+            throw new OAuthParsingException(
+                    "[K-OAuth] Failed to parse NaverRefreshTokenResponse response: " + e.getMessage(),
+                    e
+            );
+        }
+
+        if (json.has("error")) {
+            ErrorDetail detail = parseError(responseBody);
+            throw new OAuthResponseException(200, detail.errorCode(), responseBody, detail.message());
+        }
+    }
+}

--- a/src/test/java/kr/higu/request/naver/NaverRefreshTokenRequestTest.java
+++ b/src/test/java/kr/higu/request/naver/NaverRefreshTokenRequestTest.java
@@ -1,0 +1,178 @@
+package kr.higu.request.naver;
+
+import kr.higu.IHttpManager;
+import kr.higu.dto.naver.NaverRefreshTokenResponse;
+import kr.higu.exceptions.OAuthValidationException;
+import kr.higu.exceptions.detailed.OAuthParsingException;
+import kr.higu.exceptions.detailed.OAuthResponseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NaverRefreshTokenRequestTest {
+
+    @Mock
+    private IHttpManager httpManager;
+
+    @Test
+    @DisplayName("네이버 리프레시 토큰 갱신 성공")
+    void execute_Success() throws Exception {
+        // given
+        String successJson = """
+                {
+                    "access_token": "NEW_ACCESS_TOKEN",
+                    "token_type": "bearer",
+                    "expires_in": "3600"
+                }
+                """;
+        given(httpManager.post(any(URI.class), any(), any())).willReturn(successJson);
+
+        NaverRefreshTokenRequest request = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .clientSecret("SECRET")
+                .refreshToken("REFRESH_TOKEN")
+                .build();
+
+        // when
+        NaverRefreshTokenResponse response = request.execute();
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("NEW_ACCESS_TOKEN");
+        assertThat(response.tokenType()).isEqualTo("bearer");
+        assertThat(response.expiresIn()).isEqualTo("3600");
+        assertThat(response.error()).isNull();
+        assertThat(response.errorDescription()).isNull();
+    }
+
+    @Test
+    @DisplayName("네이버 리프레시 토큰 갱신 - 요청 바디에 refresh grant 파라미터 포함")
+    void execute_RequestBody_Contains_RefreshGrantParams() throws Exception {
+        // given
+        given(httpManager.post(any(URI.class), any(), any())).willReturn("""
+                {
+                    "access_token": "ACCESS",
+                    "token_type": "bearer",
+                    "expires_in": "3600"
+                }
+                """);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+
+        NaverRefreshTokenRequest request = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .clientSecret("SECRET")
+                .refreshToken("REFRESH_TOKEN")
+                .build();
+
+        // when
+        request.execute();
+
+        // then
+        org.mockito.Mockito.verify(httpManager).post(any(URI.class), any(), bodyCaptor.capture());
+        assertThat(bodyCaptor.getValue()).contains("grant_type=refresh_token");
+        assertThat(bodyCaptor.getValue()).contains("client_id=CLIENT_ID");
+        assertThat(bodyCaptor.getValue()).contains("client_secret=SECRET");
+        assertThat(bodyCaptor.getValue()).contains("refresh_token=REFRESH_TOKEN");
+        assertThat(bodyCaptor.getValue()).doesNotContain("code=");
+        assertThat(bodyCaptor.getValue()).doesNotContain("state=");
+    }
+
+    @Test
+    @DisplayName("필수 파라미터(client_id) 누락 시 빌드 에러")
+    void build_Error_When_ClientId_Is_Missing() {
+        // given
+        NaverRefreshTokenRequest.Builder builder = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientSecret("SECRET")
+                .refreshToken("REFRESH_TOKEN");
+
+        // when, then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(OAuthValidationException.class)
+                .hasMessageContaining("client_id");
+    }
+
+    @Test
+    @DisplayName("필수 파라미터(client_secret) 누락 시 빌드 에러")
+    void build_Error_When_ClientSecret_Is_Missing() {
+        // given
+        NaverRefreshTokenRequest.Builder builder = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .refreshToken("REFRESH_TOKEN");
+
+        // when, then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(OAuthValidationException.class)
+                .hasMessageContaining("client_secret");
+    }
+
+    @Test
+    @DisplayName("필수 파라미터(refresh_token) 누락 시 빌드 에러")
+    void build_Error_When_RefreshToken_Is_Missing() {
+        // given
+        NaverRefreshTokenRequest.Builder builder = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .clientSecret("SECRET");
+
+        // when, then
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(OAuthValidationException.class)
+                .hasMessageContaining("refresh_token");
+    }
+
+    @Test
+    @DisplayName("200 OK인데 바디에 에러가 있는 경우")
+    void execute_Error_With_200_Ok() throws Exception {
+        // given
+        String errorJson = """
+                {
+                    "error": "invalid_request",
+                    "error_description": "invalid refresh token"
+                }
+                """;
+        given(httpManager.post(any(URI.class), any(), any())).willReturn(errorJson);
+
+        NaverRefreshTokenRequest request = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .clientSecret("SECRET")
+                .refreshToken("REFRESH_TOKEN")
+                .build();
+
+        // when, then
+        assertThatThrownBy(request::execute)
+                .isInstanceOf(OAuthResponseException.class)
+                .satisfies(e -> {
+                    OAuthResponseException ex = (OAuthResponseException) e;
+                    assertThat(ex.getStatusCode()).isEqualTo(200);
+                    assertThat(ex.getErrorCode()).isEqualTo("invalid_request");
+                    assertThat(ex.getMessage()).contains("invalid refresh token");
+                });
+    }
+
+    @Test
+    @DisplayName("200 OK인데 malformed JSON이면 OAuthParsingException")
+    void execute_Error_With_200_Ok_MalformedJson() throws Exception {
+        // given
+        given(httpManager.post(any(URI.class), any(), any())).willReturn("not-json");
+
+        NaverRefreshTokenRequest request = new NaverRefreshTokenRequest.Builder(httpManager)
+                .clientId("CLIENT_ID")
+                .clientSecret("SECRET")
+                .refreshToken("REFRESH_TOKEN")
+                .build();
+
+        // when, then
+        assertThatThrownBy(request::execute)
+                .isInstanceOf(OAuthParsingException.class)
+                .hasMessageContaining("Failed to parse NaverRefreshTokenResponse response");
+    }
+}


### PR DESCRIPTION
## Summary
Add Naver refresh token grant support based on the official Naver Login API documentation.

This PR introduces a dedicated refresh token flow for Naver so that the library structure matches the official documentation more closely and keeps authorization code issuance and refresh token usage clearly separated.

Official reference:
https://developers.naver.com/docs/login/api/api.md#3-2--%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0-%EB%B0%9C%EA%B8%89%EA%B0%B1%EC%8B%A0%EC%82%AD%EC%A0%9C-%EC%9A%94%EC%B2%AD

## What Changed

### 1. Added dedicated refresh token response DTO
Added `NaverRefreshTokenResponse` based on the official output fields for the refresh token request.

Included fields:
- `access_token`
- `token_type`
- `expires_in`
- `error`
- `error_description`

Also adjusted `NaverTokenResponse` to continue matching the official token issuance response fields.

### 2. Added dedicated refresh token request
Added `NaverRefreshTokenRequest` as a separate request type instead of reusing or subclassing `NaverTokenRequest`.

Request behavior:
- `POST https://nid.naver.com/oauth2.0/token`
- `Content-Type: application/x-www-form-urlencoded;charset=utf-8`

Supported params:
- required
  - `grant_type=refresh_token`
  - `client_id`
  - `client_secret`
  - `refresh_token`

This request intentionally does not expose authorization-code-specific params such as:
- `code`
- `state`

### 3. Added client entry point
Added `NaverClient#refreshToken()` so the public API clearly separates the two token flows:
- `getToken()` for authorization code token issuance
- `refreshToken()` for refresh token grant

### 4. Added tests
Added `NaverRefreshTokenRequestTest` covering:
- successful refresh response parsing
- request body includes `grant_type=refresh_token`
- validation failure when `client_id` is missing
- validation failure when `client_secret` is missing
- validation failure when `refresh_token` is missing
- HTTP 200 with `error` body is converted to `OAuthResponseException`
- malformed JSON response triggers `OAuthParsingException`

### 5. Updated documentation
Updated both `README.md` and `README.ko.md` to include:
- Naver refresh token example
- the distinction between token issuance and token refresh
- Naver-specific behavior where HTTP 200 responses may still contain `error` and `error_description`
- clarification that the refresh response does not include `refresh_token` according to the official documentation

## Why a separate request type?
Although Naver uses the same token endpoint for issuance and refresh, the required parameters and intended usage are different.

This PR favors:
- official documentation alignment
- explicit public API design
- clearer discoverability for library users

instead of trying to reuse the authorization code request type.

## Validation
- Ran `./gradlew test`
- All tests passed

## Out of Scope
This PR does not include:
- Naver token delete (`grant_type=delete`)
- a version bump to `0.1.2`

## Notes
The version bump is planned later, after both Kakao and Naver refresh token support are merged into `main`.
